### PR TITLE
ci: add timeouts to workflow jobs

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -19,6 +19,7 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -36,6 +37,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: build
     permissions:
       pages: write
@@ -45,4 +47,5 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy site
+        id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
## Changes

- Add `timeout-minutes: 10` to both jobs in `github-pages.yaml`.
- Add `id: deployment` to the `Deploy site` step.

## Why

An E2E job in another repository hung for 60 minutes today when `apt-get update` could not reach its mirror. Because that job had no `timeout-minutes`, the [default of 360 minutes](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes) applied, so a stuck job would have burned six hours of runner time before being killed.

The value is derived from this workflow's own history: the last 30 successful runs are all well under two minutes, so 10 minutes leaves a wide margin while still catching a hang quickly.

Verified with `actionlint` and `zizmor --offline`.

The `id` is a separate one-line fix for an existing defect. The job declares `environment.url: ${{ steps.deployment.outputs.page_url }}`, but no step carried that id, so the expression resolved to nothing and the environment URL was always empty. `actionlint` reports it as `property "deployment" is not defined in object type {}`; with the id in place that warning is gone.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
