### PR TITLE
fix: restore the production build and gate main behind CI

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,9 +2,6 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
     'github>corrupt952/renovate-config:default.json5',
-
-    // CAUTION: This repository has no tests, so skip status checks
-    ':skipStatusChecks',
   ],
 
   assignees: ['@corrupt952'],

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "*.md"
+      - "LICENSE"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "*.md"
+      - "LICENSE"
+
+# Least privilege: deny all at workflow level, grant per job.
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # pnpm must be on PATH before setup-node, otherwise `cache: pnpm` fails.
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: lts/*
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # `pnpm lint` is deliberately absent: eslint-config-next pulls in
+      # eslint-plugin-react, which supports eslint <=9, and typescript-eslint,
+      # which supports typescript <6.1. Both caps are violated by the versions
+      # this repository is on, so the eslint stack cannot run at all. Migrating
+      # to biome is tracked separately; lint joins this job once that lands.
+      - run: pnpm build

--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -24,10 +24,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # pnpm must be on PATH before setup-node, otherwise `cache: pnpm` fails.
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 24
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+          node-version: lts/*
+          cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - name: Upload artifact

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  unrs-resolver: true

--- a/src/components/Elements/Icon/SocialIcon.tsx
+++ b/src/components/Elements/Icon/SocialIcon.tsx
@@ -1,0 +1,31 @@
+type SocialIconProps = {
+  className?: string;
+};
+
+// lucide-react dropped every brand icon in v1, so the marks are inlined here.
+// See https://lucide.dev — "Removed brand icons, see our brand logo statement".
+export const GithubIcon = ({ className = 'w-8 h-8' }: SocialIconProps) => {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z" />
+    </svg>
+  );
+};
+
+export const XIcon = ({ className = 'w-8 h-8' }: SocialIconProps) => {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+};

--- a/src/components/Elements/Icon/index.ts
+++ b/src/components/Elements/Icon/index.ts
@@ -1,2 +1,3 @@
 export * from './LogoIcon';
 export * from './AvatarIcon';
+export * from './SocialIcon';

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,5 @@
-import { Mail, Github, Twitter } from 'lucide-react';
-import { AvatarIcon } from '@/components/Elements/Icon';
+import { Mail } from 'lucide-react';
+import { AvatarIcon, GithubIcon, XIcon } from '@/components/Elements/Icon';
 import LinkText from '@/components/Elements/LinkText';
 import { useTranslation } from '@/libs/i18n';
 import Head from 'next/head';
@@ -15,12 +15,12 @@ export default function Home() {
     {
       name: 'github',
       href: 'https://github.com/corrupt952',
-      icon: <Github className="w-8 h-8" />,
+      icon: <GithubIcon />,
     },
     {
       name: 'twitter',
       href: 'https://twitter.com/corrupt952',
-      icon: <Twitter className="w-8 h-8" />,
+      icon: <XIcon />,
     },
   ];
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "lib": [
       "dom",
       "dom.iterable",
@@ -13,7 +13,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary

The build has failed on main since `#1034` on 2026-04-05 — **127 commits and roughly four and a half months**. There was no single cause. Three independent breakages accumulated, each landed by a dependency bump that nothing verified. This fixes all three and closes the gap that let them through.

## Causes and fixes

### 1. lucide-react v1 removed every brand icon

The `Github` and `Twitter` imports stopped resolving, failing the type check:

```
src/pages/index.tsx(1,16): error TS2305: Module '"lucide-react"' has no exported member 'Github'.
```

The lucide 1.0.1 release notes state `Removed brand icons, see our brand logo statement for more details.` There is no replacement export — inspecting all 3537 exports of `lucide-react@1.31.0` confirms `Github`, `Twitter`, `Facebook`, `Linkedin` and the rest are gone.

Inlined as `SocialIcon.tsx`. The path data matches `Footer.astro` on `feat/static-migration`, so the two branches stay consistent.

### 2. TypeScript 7 removed `target: es5`

```
tsconfig.json(3,15): error TS5108: Option 'target=ES5' has been removed.
```

Moved to `es2017`, and `moduleResolution` to `bundler` — the value `next build` was already rewriting on every run.

### 3. pnpm 11 turns ignored build scripts into a failed install

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: unrs-resolver@1.12.2
```

`unrs-resolver` reaches the tree through `eslint-config-next` → `eslint-import-resolver-typescript` and needs its postinstall. Declared in `pnpm-workspace.yaml` using the same `allowBuilds` form as labee/product-sites.

## Preventing a repeat

**Adds `.github/workflows/ci.yaml`.** Nothing checked a change before it landed — the only workflow ran on push to main, so a broken build was discoverable solely after the fact. Shaped after product-sites: `permissions: {}` at the workflow level with per-job grants, SHA-pinned actions, `persist-credentials: false`, and per-PR `concurrency`.

**Drops `:skipStatusChecks` from `.github/renovate.json5`.** This is the structural cause. Renovate automerged without ever looking at a result, so all three breakages reached main unverified. There is a check to wait for now.

**Aligns the deploy workflow.** `pnpm/action-setup` now precedes `setup-node`, which is what lets `cache: pnpm` resolve a store path, and the Node version follows `lts/*` so it tracks `mise.toml`.

## Verification

Run from a clean tree on pnpm 11.21.0, matching what CI does:

- `pnpm install --frozen-lockfile` → exit 0
- `pnpm build` → exit 0, 22 pages emitted, sitemap generated
- Both inlined SVG paths confirmed present in `out/index.html`

## Known gap

**`pnpm lint` still cannot run.** The eslint stack is at a dead end:

- `eslint-plugin-react` caps at `eslint ^9.7` even in its latest 7.37.5 — **ESLint 10 is unsupported**
- `typescript-eslint` caps at `typescript <6.1.0` even in its latest 8.67.0 — **no TS 7 compatible release exists**

Both arrive through `eslint-config-next`, so lint only runs again if eslint and TypeScript are rolled back to 9 and 6 — a fight with Renovate that never ends.

Migrating to biome resolves it instead, and matches both `feat/static-migration` and product-sites. That is a separate PR: the reformat touches all of `src`, and mixing it in here would make the diff unreviewable. Lint joins the CI job there.

Worth noting that once biome removes `eslint-config-next`, `unrs-resolver` leaves the dependency tree and the `allowBuilds` entry above becomes unnecessary.