### PR TITLE
ci: add concurrency groups to workflows

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -2,7 +2,7 @@ name: Deploy site to GitHub Pages
 
 concurrency:
   group: 'pages'
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 on:
   push:

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Changes

- Add `concurrency` to `zizmor.yaml`.
- Flip `github-pages.yaml` to `cancel-in-progress: false`, keeping `group: "pages"`.

## Why

Without a `concurrency` group, pushing to a PR leaves the previous run going, so several runs of the same workflow race for the same commit range. `sallyport` and `dotfiles` already use the CI form below; this brings the rest in line.

For CI and lint workflows, cancelling the older run is the point:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

For release and deploy workflows the opposite is true — interrupting one halfway can leave a partial release or a half-finished deployment — so those get `cancel-in-progress: false`.

Verified with `actionlint` and `zizmor --offline`.

GitHub's own Pages starter workflows ([static](https://github.com/actions/starter-workflows/blob/main/pages/static.yml), [jekyll](https://github.com/actions/starter-workflows/blob/main/pages/jekyll.yml), [nextjs](https://github.com/actions/starter-workflows/blob/main/pages/nextjs.yml)) all pair `group: "pages"` with `cancel-in-progress: false` for exactly this reason. The group name is kept as-is since it is the Pages convention.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
