### PR TITLE
docs: update the README to match the current setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,27 @@
 
 Repository for the [zuki.dev](https://zuki.dev)
 
+Next.js with static export, deployed to GitHub Pages.
+
 ## Requirements
 
-- [aqua](https://github.com/aquaproj/aqua)
+- [mise](https://mise.jdx.dev/)
 
 ## Setup
 
-1. Install Node.js via aqua: `aqua i`
-1. Install packages: `npm i`
+1. Install Node.js via mise: `mise install`
+1. Enable Corepack so the pinned pnpm is used: `corepack enable`
+1. Install packages: `pnpm install --frozen-lockfile`
 
 ## Run
 
-1. Run server: `npm run dev`
+1. Run server: `pnpm dev`
 1. Open [localhost:3000](http://localhost:3000)
+
+## Checks
+
+These are the same commands CI runs.
+
+- Lint: `pnpm lint` (`pnpm lint:fix` to apply)
+- Format: `pnpm format:check` (`pnpm format` to apply)
+- Build: `pnpm build`


### PR DESCRIPTION
## Changes

Bring the README in line with what the repository actually uses.

| | Was | Is |
|---|---|---|
| Toolchain | aqua | `mise.toml` (`node = "lts"`) |
| Package manager | npm | pnpm, pinned via `packageManager: pnpm@11.21.0` |

Following the old instructions would install the wrong toolchain and produce a `package-lock.json` next to the committed `pnpm-lock.yaml`.

Also added a one-line description of what this is (Next.js with static export, deployed to GitHub Pages) and a Checks section listing the commands CI runs, so the lint and format entries added with the biome migration are discoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
